### PR TITLE
Adds one-liner npm run script for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "css-loader": "0.23.1",
     "eslint": "3.7.1",
     "eslint-config-google": "0.6.0",
+    "gh-pages": "0.11.0",
     "hjs-webpack": "8.1.0",
     "html-loader": "0.4.4",
     "image-size": "0.5.0",
@@ -78,8 +79,9 @@
     "build": "webpack",
     "build:nofollow": "echo 'User-agent: *\nDisallow: /' > ./build/robots.txt",
     "start": "hjs-dev-server",
-    "predeploy": "npm run build",
     "prestage": "npm run build && npm run build:nofollow",
-    "stage": "surge ./build v2.gf-project-1.kennethormandy.com"
+    "stage": "surge ./build v2.gf-project-1.kennethormandy.com",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d ./build"
   }
 }


### PR DESCRIPTION
I haven’t tested this module within this repository yet, when we are ready to do a test deploy (or redeploy later) it should be a one-liner now:

``` sh
npm run deploy
```

…which will do all the GitHub Pages orphan branch juggling, etc.
